### PR TITLE
fix: pydantic deprecation max_items to max_length

### DIFF
--- a/scope3ai/api/types.py
+++ b/scope3ai/api/types.py
@@ -175,9 +175,9 @@ class ImpactRequestRow(BaseModel):
     input_tokens: Optional[int] = Field(None, ge=0, le=100000000)
     output_tokens: Optional[int] = Field(None, ge=0, le=100000000)
     input_audio_seconds: Optional[int] = Field(None, ge=0, le=100000)
-    input_images: Optional[List[ImageDimensions]] = Field(None, max_items=100)
+    input_images: Optional[List[ImageDimensions]] = Field(None, max_length=100)
     input_steps: Optional[int] = Field(None, ge=1, le=10000)
-    output_images: Optional[List[ImageDimensions]] = Field(None, max_items=100)
+    output_images: Optional[List[ImageDimensions]] = Field(None, max_length=100)
     output_video_frames: Optional[int] = Field(None, ge=0, le=100000000)
     output_video_resolution: Optional[int] = None
 
@@ -241,7 +241,7 @@ class ImpactResponse(BaseModel):
 class ImpactRequest(BaseModel):
     """Final request structure for the API"""
 
-    rows: List[ImpactRequestRow] = Field(..., max_items=1000)
+    rows: List[ImpactRequestRow] = Field(..., max_length=1000)
 
 
 class Scope3AIContext(BaseModel):


### PR DESCRIPTION
This PR fixes the pydantic warning:

```
  /xxx/scope3/scope3ai-py/.venv/lib/python3.12/site-packages/pydantic/fields.py:1017: PydanticDeprecatedSince20: `max_items` is deprecated and will be removed, use `max_length` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
    warn('`max_items` is deprecated and will be removed, use `max_length` instead', DeprecationWarning)
```