### PR TITLE
feat(metadata): include many metadata accessible at global or tracer level

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,30 +46,52 @@ Roadmap:
 
 ### Initializing the SDK
 
-The SDK can be initialized with your API key and custom configurations.
+The SDK can be initialized with the following parameters, from environemnt variable or when calling `ScopeAI.init(...)`:
+
+| Attribute             | Environment Variable     | Description    | Can be customized per tracer |
+|-----------------------|--------------------------|--------------------------------|------------------------------|
+| **`api_key`**         | **`SCOPE3AI_API_KEY`**   | Your Scope3AI API key. Default: `None` | **No**                       |
+| `api_url`             | `SCOPE3AI_API_URL`       | The API endpoint URL. Default: `https://aiapi.scope3.com` | No                           |
+| `enable_debug_logging`| `SCOPE3AI_DEBUG_LOGGING` | Enable debug logging. Default: `False` | No                           |
+| `sync_mode`           | `SCOPE3AI_SYNC_MODE`     | Enable synchronous mode. Default: `False` | No                           |
+| `environment`         | `SCOPE3AI_ENVIRONMENT`   | The user-defined environment name, such as "production" or "staging". Default: `None` | No                           |
+| `application_id`      | `SCOPE3AI_APPLICATION_ID`| The user-defined application identifier. Default: `default` | ✅ Yes                       |
+| `client_id`           | `SCOPE3AI_CLIENT_ID`     | The user-defined client identifier. Default: `None` | ✅ Yes                       |
+| `project_id`          | `SCOPE3AI_PROJECT_ID`    | The user-defined project identifier. Default: `None` | ✅ Yes                       |
+| `session_id`          | -                        | The user-defined session identifier, used to track user session. Default `None`. Available only at tracer() level. | ✅ Yes                       |
+
+
+**Here is an example of how to initialize the SDK**:
 
 ```python
 from scope3ai import Scope3AI
 
 scope3 = Scope3AI.init(
-    api_key="YOUR_API_KEY",  # Replace "YOUR_API_KEY" with your actual key
-    api_url="https://api.scope3.ai/v1",  # Optional: Specify the API URL
-    enable_debug_logging=False,  # Enable debug logging (default: False)
-    sync_mode=False,  # Enable synchronous mode when sending telemetry to the API (default: False)
+    api_key="YOUR_API_KEY",
+    environment="staging",
+    application_id="my-app",
+    project_id="my-webinar-2024"
 )
 ```
 
-### Environment variables
+**You could also use environment variables to initialize the SDK**:
 
-You can also use environment variable to setup the SDK:
+1. Create a `.env` file with the following content:
 
-- `SCOPE3AI_API_KEY`: Your Scope3AI API key
-- `SCOPE3AI_API_URL`: The API endpoint URL. Default: `https://api.scope3.ai/v1`
-- `SCOPE3AI_SYNC_MODE`: If `True`, every interaction will be send synchronously to the API, otherwise it will use a background worker. Default: `False`
+```env
+SCOPE3AI_API_KEY=YOUR_API_KEY
+SCOPE3AI_ENVIRONMENT=staging
+SCOPE3AI_APPLICATION_ID=my-app
+SCOPE3AI_PROJECT_ID=my-webinar-2024
+```
+
+2. Use dotenv to load the environment variables:
 
 ```python
+from dotenv import load_dotenv
 from scope3ai import Scope3AI
 
+load_dotenv()
 scope3 = Scope3AI.init()
 ```
 
@@ -92,6 +114,23 @@ with scope3.trace() as tracer:
     print(f"Total Energy Wh: {impact.total_energy_wh}")
     print(f"Total GCO2e: {impact.total_gco2e}")
     print(f"Total MLH2O: {impact.total_mlh2o}")
+```
+
+### 2. Configure per-tracer metadata
+
+Some global metadata can be overridden per-tracer. This is useful when you want to mark a specific tracer with a different `client_id` or `project_id`.
+
+```python
+with scope3.trace(client_id="my-client", project_id="my-project") as tracer:
+    ...
+```
+
+You can track session with the `session_id` parameter of the tracer. This is only for categorizing the traces in the dashboard.
+but works at tracer level, not in global level like `client_id` or `project_id` or others.
+
+```python
+with scope3.trace(session_id="my-session") as tracer:
+    ...
 ```
 
 ### 2. Single interaction

--- a/scope3ai/api/defaults.py
+++ b/scope3ai/api/defaults.py
@@ -1,1 +1,2 @@
 DEFAULT_API_URL = "https://aiapi.scope3.com"
+DEFAULT_APPLICATION_ID = "default"

--- a/scope3ai/api/tracer.py
+++ b/scope3ai/api/tracer.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+from uuid import uuid4
 
 from .typesgen import ImpactResponse, ModeledRow
 
@@ -8,15 +9,26 @@ class Tracer:
         self,
         name: str = None,
         keep_traces: bool = False,
+        client_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        application_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        trace_id: Optional[str] = None,
     ) -> None:
         from scope3ai.lib import Scope3AI
 
+        self.trace_id = trace_id or uuid4().hex
         self.scope3ai = Scope3AI.get_instance()
         self.name = name
         self.keep_traces = keep_traces
         self.children: List[Tracer] = []
         self.rows: List[ModeledRow] = []
         self.traces = []  # type: List[Scope3AIContext]
+
+        self.client_id = client_id
+        self.project_id = project_id
+        self.application_id = application_id
+        self.session_id = session_id
 
     def impact(self, timeout: Optional[int] = None) -> ImpactResponse:
         """

--- a/scope3ai/lib.py
+++ b/scope3ai/lib.py
@@ -444,5 +444,8 @@ class Scope3AI:
             tracer.application_id if tracer else None,
             self.application_id,
         )
-        if row.session_id is None and tracer:
-            row.session_id = tracer.session_id
+        set_only_if(
+            row,
+            "session_id",
+            tracer.session_id if tracer else None,
+        )

--- a/scope3ai/worker.py
+++ b/scope3ai/worker.py
@@ -1,10 +1,8 @@
 import logging
 import queue
 import threading
-from time import sleep
+from time import monotonic, sleep
 from typing import Callable, Optional
-
-from time import monotonic
 
 logger = logging.getLogger("scope3ai.worker")
 

--- a/tests/test_lib_metadata.py
+++ b/tests/test_lib_metadata.py
@@ -1,5 +1,6 @@
-import pytest
 from typing import Optional
+
+import pytest
 
 
 def test_lib_init_default():
@@ -7,7 +8,7 @@ def test_lib_init_default():
 
     scope3: Optional[Scope3AI] = None
     try:
-        scope3 = Scope3AI.init(providers=[])
+        scope3 = Scope3AI.init(api_key="dummy", providers=[])
         assert scope3.environment is None
         assert scope3.application_id == "default"
         assert scope3.client_id is None
@@ -37,7 +38,7 @@ def test_lib_init_env(init_env):
 
     scope3: Optional[Scope3AI] = None
     try:
-        scope3 = Scope3AI.init(providers=[])
+        scope3 = Scope3AI.init(api_key="dummy", providers=[])
         assert scope3.environment == "environment"
         assert scope3.application_id == "application_id"
         assert scope3.client_id == "client_id"
@@ -53,6 +54,7 @@ def test_lib_init_precedence(init_env):
     scope3: Optional[Scope3AI] = None
     try:
         scope3 = Scope3AI.init(
+            api_key="dummy",
             environment="environment_2",
             application_id="application_id_2",
             client_id="client_id_2",

--- a/tests/test_lib_metadata.py
+++ b/tests/test_lib_metadata.py
@@ -89,6 +89,8 @@ def test_impact_row_no_tracer(init_env, tracer_init):
     assert request.client_id == "client_id"
     assert request.project_id == "project_id"
 
+    tracer_init._worker.resume()
+
 
 def test_impact_row_with_tracer(init_env, tracer_init):
     from scope3ai.api.types import ImpactRow
@@ -113,6 +115,8 @@ def test_impact_row_with_tracer(init_env, tracer_init):
         assert request.application_id == "application_id_2"
         assert request.client_id == "client_id_2"
         assert request.project_id == "project_id_2"
+
+    tracer_init._worker.resume()
 
 
 def test_impact_row_with_nested_tracer(init_env, tracer_init):
@@ -141,6 +145,8 @@ def test_impact_row_with_nested_tracer(init_env, tracer_init):
             assert request.client_id == "client_id_2"
             assert request.project_id == "project_id_3"
 
+    tracer_init._worker.resume()
+
 
 def test_impact_row_with_session_id(tracer_init):
     from scope3ai.api.types import ImpactRow
@@ -159,6 +165,8 @@ def test_impact_row_with_session_id(tracer_init):
         assert request.request_id is not None
         assert request.trace_id == tracer.trace_id
         assert request.session_id == "session_id_1"
+
+    tracer_init._worker.resume()
 
 
 def test_impact_row_nested_with_session_id(tracer_init):
@@ -181,3 +189,5 @@ def test_impact_row_nested_with_session_id(tracer_init):
             assert request.request_id is not None
             assert request.trace_id == tracer.trace_id
             assert request.session_id == "session_id_2"
+
+    tracer_init._worker.resume()

--- a/tests/test_lib_metadata.py
+++ b/tests/test_lib_metadata.py
@@ -1,0 +1,181 @@
+import pytest
+from typing import Optional
+
+
+def test_lib_init_default():
+    from scope3ai import Scope3AI
+
+    scope3: Optional[Scope3AI] = None
+    try:
+        scope3 = Scope3AI.init(providers=[])
+        assert scope3.environment is None
+        assert scope3.application_id == "default"
+        assert scope3.client_id is None
+        assert scope3.project_id is None
+    finally:
+        if scope3:
+            scope3.close()
+
+
+@pytest.fixture
+def init_env():
+    import os
+
+    os.environ["SCOPE3AI_ENVIRONMENT"] = "environment"
+    os.environ["SCOPE3AI_APPLICATION_ID"] = "application_id"
+    os.environ["SCOPE3AI_CLIENT_ID"] = "client_id"
+    os.environ["SCOPE3AI_PROJECT_ID"] = "project_id"
+    yield
+    del os.environ["SCOPE3AI_ENVIRONMENT"]
+    del os.environ["SCOPE3AI_APPLICATION_ID"]
+    del os.environ["SCOPE3AI_CLIENT_ID"]
+    del os.environ["SCOPE3AI_PROJECT_ID"]
+
+
+def test_lib_init_env(init_env):
+    from scope3ai import Scope3AI
+
+    scope3: Optional[Scope3AI] = None
+    try:
+        scope3 = Scope3AI.init(providers=[])
+        assert scope3.environment == "environment"
+        assert scope3.application_id == "application_id"
+        assert scope3.client_id == "client_id"
+        assert scope3.project_id == "project_id"
+    finally:
+        if scope3:
+            scope3.close()
+
+
+def test_lib_init_precedence(init_env):
+    from scope3ai import Scope3AI
+
+    scope3: Optional[Scope3AI] = None
+    try:
+        scope3 = Scope3AI.init(
+            environment="environment_2",
+            application_id="application_id_2",
+            client_id="client_id_2",
+            project_id="project_id_2",
+            providers=[],
+        )
+        assert scope3.environment == "environment_2"
+        assert scope3.application_id == "application_id_2"
+        assert scope3.client_id == "client_id_2"
+        assert scope3.project_id == "project_id_2"
+    finally:
+        if scope3:
+            scope3.close()
+
+
+def test_impact_row_no_tracer(init_env, tracer_init):
+    from scope3ai.api.types import ImpactRow
+
+    # pause the background worker
+    tracer_init._ensure_worker()
+    tracer_init._worker.pause()
+
+    impact = ImpactRow(model_id="gpt_4o", input_tokens=100, output_tokens=100)
+    ctx = tracer_init.submit_impact(impact)
+    request = ctx.request
+    assert request.utc_datetime is not None
+    assert request.request_id is not None
+    assert request.trace_id is None
+    assert request.session_id is None
+    assert request.environment == "environment"
+    assert request.application_id == "application_id"
+    assert request.client_id == "client_id"
+    assert request.project_id == "project_id"
+
+
+def test_impact_row_with_tracer(init_env, tracer_init):
+    from scope3ai.api.types import ImpactRow
+
+    # pause the background worker
+    tracer_init._ensure_worker()
+    tracer_init._worker.pause()
+
+    with tracer_init.trace(
+        application_id="application_id_2",
+        client_id="client_id_2",
+        project_id="project_id_2",
+    ) as tracer:
+        impact = ImpactRow(model_id="gpt_4o", input_tokens=100, output_tokens=100)
+        ctx = tracer_init.submit_impact(impact)
+        request = ctx.request
+        assert request.utc_datetime is not None
+        assert request.request_id is not None
+        assert request.session_id is None
+        assert request.trace_id == tracer.trace_id
+        assert request.environment == "environment"
+        assert request.application_id == "application_id_2"
+        assert request.client_id == "client_id_2"
+        assert request.project_id == "project_id_2"
+
+
+def test_impact_row_with_nested_tracer(init_env, tracer_init):
+    from scope3ai.api.types import ImpactRow
+
+    # pause the background worker
+    tracer_init._ensure_worker()
+    tracer_init._worker.pause()
+
+    with tracer_init.trace(
+        application_id="application_id_2",
+        client_id="client_id_2",
+    ) as root_tracer:
+        with tracer_init.trace(
+            project_id="project_id_3",
+        ):
+            impact = ImpactRow(model_id="gpt_4o", input_tokens=100, output_tokens=100)
+            ctx = tracer_init.submit_impact(impact)
+            request = ctx.request
+            assert request.utc_datetime is not None
+            assert request.request_id is not None
+            assert request.session_id is None
+            assert request.trace_id == root_tracer.trace_id
+            assert request.environment == "environment"
+            assert request.application_id == "application_id_2"
+            assert request.client_id == "client_id_2"
+            assert request.project_id == "project_id_3"
+
+
+def test_impact_row_with_session_id(tracer_init):
+    from scope3ai.api.types import ImpactRow
+
+    # pause the background worker
+    tracer_init._ensure_worker()
+    tracer_init._worker.pause()
+
+    with tracer_init.trace(
+        session_id="session_id_1",
+    ) as tracer:
+        impact = ImpactRow(model_id="gpt_4o", input_tokens=100, output_tokens=100)
+        ctx = tracer_init.submit_impact(impact)
+        request = ctx.request
+        assert request.utc_datetime is not None
+        assert request.request_id is not None
+        assert request.trace_id == tracer.trace_id
+        assert request.session_id == "session_id_1"
+
+
+def test_impact_row_nested_with_session_id(tracer_init):
+    from scope3ai.api.types import ImpactRow
+
+    # pause the background worker
+    tracer_init._ensure_worker()
+    tracer_init._worker.pause()
+
+    with tracer_init.trace(
+        session_id="session_id_1",
+    ) as tracer:
+        with tracer_init.trace(
+            session_id="session_id_2",
+        ):
+            impact = ImpactRow(model_id="gpt_4o", input_tokens=100, output_tokens=100)
+            ctx = tracer_init.submit_impact(impact)
+            request = ctx.request
+            assert request.utc_datetime is not None
+            assert request.request_id is not None
+            assert request.trace_id == tracer.trace_id
+            assert request.session_id == "session_id_2"


### PR DESCRIPTION
This PR include the initialization of many new metadata variables that are available in the API:

- `environment`: env or sdk init
- `project_id`: env, sdk init or tracer init
- `application_id`: env, sdk init or tracer init
- `client_id`: env, sdk init or tracer init
- `session_id`: tracer init

Some more fields are set now:
- `utc_datetime` is set
- `request_id` is set with one uuid every time the ImpactRow is sent
- `trace_id` is set with the highest root tracer
- `session_id` is set at tracer init if the user provide it


One trick in this PR is how the fields are set in the `ImpactRow`. If we set a field to `None`, it will be included in the json sent as we use `model_dump` with `exclude_unset=True`. 
If we sent metadata with None (let's say `application_id: None`), the mock server will fail, and the test suite too.

So the function today set the first possible value of the values passed.